### PR TITLE
[FEATURE] Améliorer l'information des utilisateurs en cas d'incident

### DIFF
--- a/src/styles/components/_hot-news.scss
+++ b/src/styles/components/_hot-news.scss
@@ -9,6 +9,7 @@
   color: $dark-blue;
   font-family: 'Open Sans', Arial, sans-serif;
   font-size: 0.75rem;
+  text-align: center;
 
   @media (min-width: 768px) {
     top: 0;

--- a/src/styles/layout/_app-header.scss
+++ b/src/styles/layout/_app-header.scss
@@ -6,6 +6,7 @@
   justify-content: space-between;
   align-items: center;
   top: 0;
+  flex-wrap: wrap;
 
   &__white{
     background-color: $white;

--- a/src/templates/PageHeader.twig
+++ b/src/templates/PageHeader.twig
@@ -10,7 +10,7 @@
         </div>-->
         {% if portal.current_tab == "home"  %}
             <div class=" pix-app-header__home">
-                <img class="pix-app-header__logo" src="https://app.pix.fr/images/pix-logo-blanc.svg" alt="Pix">
+                <img class="pix-app-header__logo" src="https://s3-eu-central-1.amazonaws.com/euc-cdn.freshdesk.com/data/helpdesk/attachments/production/2015052769521/original/S2_GH7ODoFoBKtiqf_COQdTvGBpZdVQ4Vg.png?1619440972" alt="Pix">
                 <span class="pix-app-header__title" >
                     {% if portal.current_language.code == "fr" %}
                         Centre d'aide
@@ -22,7 +22,7 @@
         {% else %}
             <div class="pix-app-header__white">
                 <div class="pix-app-header__left">
-                    <img class="pix-app-header__logo" src="https://pix.fr/images/pix-logo.svg" alt="Pix">
+                    <img class="pix-app-header__logo" src="https://s3-eu-central-1.amazonaws.com/euc-cdn.freshdesk.com/data/helpdesk/attachments/production/2015052769380/original/2qGndtTgnnqS-fZWIdsTzdctL3SODwhzbg.png?1619440911" alt="Pix">
                     <a href="https://support.pix.org/" class="pix-app-header__title pix-app-header__title--black">
                         {% if portal.current_language.code == "fr" %}
                             Retour à l'accueil du centre d'aide

--- a/src/templates/PageHeader.twig
+++ b/src/templates/PageHeader.twig
@@ -1,7 +1,7 @@
 {% if  portal.current_page != 'csat_survey' %}
     <header class="pix-app-header">
         <!-- Bandeau Hot News -->
-        <!--<div class="hot-news"><center>Notre hébergeur rencontre actuellement quelques perturbations pouvant entraîner des ralentissements sur Pix, le problème est en cours de résolution, merci pour votre compréhension.</center></div>-->
+        <!--<div class="hot-news">Notre hébergeur rencontre actuellement quelques perturbations pouvant entraîner des ralentissements sur Pix, le problème est en cours de résolution, merci pour votre compréhension.</div>-->
         {% if portal.current_tab == "home"  %}
             <div class=" pix-app-header__home">
                 <img class="pix-app-header__logo" src="https://app.pix.fr/images/pix-logo-blanc.svg" alt="Pix">

--- a/src/templates/PageHeader.twig
+++ b/src/templates/PageHeader.twig
@@ -1,7 +1,13 @@
 {% if  portal.current_page != 'csat_survey' %}
     <header class="pix-app-header">
         <!-- Bandeau Hot News -->
-        <!--<div class="hot-news">Notre hébergeur rencontre actuellement quelques perturbations pouvant entraîner des ralentissements sur Pix, le problème est en cours de résolution, merci pour votre compréhension.</div>-->
+        <!--<div class="hot-news">
+            {% if portal.current_language.code == "fr" %}
+                Nos applications Pix rencontrent des perturbations pouvant causer des ralentissements, le problème est en cours de résolution, merci pour votre compréhension.
+            {% elsif portal.current_language.code == "en" %}
+                Pix is currently experiencing some disruptions that may cause slowdowns. Our team is working hard to solve the problem! Thank you for your understanding.
+            {% endif %}
+        </div>-->
         {% if portal.current_tab == "home"  %}
             <div class=" pix-app-header__home">
                 <img class="pix-app-header__logo" src="https://app.pix.fr/images/pix-logo-blanc.svg" alt="Pix">


### PR DESCRIPTION
## :unicorn: Problème

L'affichage de la bannière incident sur le site support lors des incidents du 26 avril a permis de remonter plusieurs problèmes :
1. La bannière occupe uniquement la moitié de la largeur de la page
2. Le texte est centré avec une balise obsolète `<center>`
3. Le texte de la bannière n'est pas traduit en anglais
4. Le logo Pix affiché dans l'en-tête est hébergé dans Pix App et ne s'affiche pas si Pix App n'est pas disponible

## :robot: Solution

1. Corriger le code CSS pour que la bannière incident occupe la largeur de la page
2. Centrer la bannière avec une propriété CSS
3. Traduire le texte de la bannière en anglais
4. Le logo Pix affiché dans l'en-tête est hébergé dans Pix App et ne s'affiche pas si Pix App n'est pas disponible

## :rainbow: Remarques

Ces modifications ont déjà été déployées sur le site FreshDesk
