### PR TITLE
[FEATURE] Utiliser le même header pour les enquete de satisfaction (csat_survey)

### DIFF
--- a/src/styles/layout/_app-header.scss
+++ b/src/styles/layout/_app-header.scss
@@ -1,7 +1,6 @@
 .pix-app-header {
   width: 100%;
   height: 70px;
-  position: absolute;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/src/templates/PageHeader.twig
+++ b/src/templates/PageHeader.twig
@@ -1,28 +1,30 @@
-{% if  portal.current_page != 'csat_survey' %}
-    <header class="pix-app-header">
-        <!-- Bandeau Hot News -->
-        <!--<div class="hot-news">
-            {% if portal.current_language.code == "fr" %}
-                Nos applications Pix rencontrent des perturbations pouvant causer des ralentissements, le problème est en cours de résolution, merci pour votre compréhension.
-            {% elsif portal.current_language.code == "en" %}
-                Pix is currently experiencing some disruptions that may cause slowdowns. Our team is working hard to solve the problem! Thank you for your understanding.
-            {% endif %}
-        </div>-->
-        {% if portal.current_tab == "home"  %}
-            <div class=" pix-app-header__home">
-                <img class="pix-app-header__logo" src="https://s3-eu-central-1.amazonaws.com/euc-cdn.freshdesk.com/data/helpdesk/attachments/production/2015052769521/original/S2_GH7ODoFoBKtiqf_COQdTvGBpZdVQ4Vg.png?1619440972" alt="Pix">
-                <span class="pix-app-header__title" >
-                    {% if portal.current_language.code == "fr" %}
-                        Centre d'aide
-                    {% elsif portal.current_language.code == "en" %}
-                        Help centre
-                    {% endif %}
-                </span>
-            </div>
-        {% else %}
-            <div class="pix-app-header__white">
-                <div class="pix-app-header__left">
-                    <img class="pix-app-header__logo" src="https://s3-eu-central-1.amazonaws.com/euc-cdn.freshdesk.com/data/helpdesk/attachments/production/2015052769380/original/2qGndtTgnnqS-fZWIdsTzdctL3SODwhzbg.png?1619440911" alt="Pix">
+<header class="pix-app-header">
+    <!-- Bandeau Hot News -->
+    {% if  portal.current_page != 'csat_survey' %}
+    <!--<div class="hot-news">
+        {% if portal.current_language.code == "fr" %}
+            Nos applications Pix rencontrent des perturbations pouvant causer des ralentissements, le problème est en cours de résolution, merci pour votre compréhension.
+        {% elsif portal.current_language.code == "en" %}
+            Pix is currently experiencing some disruptions that may cause slowdowns. Our team is working hard to solve the problem! Thank you for your understanding.
+        {% endif %}
+    </div>-->
+    {% endif %}
+    {% if portal.current_tab == "home"  %}
+        <div class=" pix-app-header__home">
+            <img class="pix-app-header__logo" src="https://s3-eu-central-1.amazonaws.com/euc-cdn.freshdesk.com/data/helpdesk/attachments/production/2015052769521/original/S2_GH7ODoFoBKtiqf_COQdTvGBpZdVQ4Vg.png?1619440972" alt="Pix">
+            <span class="pix-app-header__title" >
+                {% if portal.current_language.code == "fr" %}
+                    Centre d'aide
+                {% elsif portal.current_language.code == "en" %}
+                    Help centre
+                {% endif %}
+            </span>
+        </div>
+    {% else %}
+        <div class="pix-app-header__white">
+            <div class="pix-app-header__left">
+                <img class="pix-app-header__logo" src="https://s3-eu-central-1.amazonaws.com/euc-cdn.freshdesk.com/data/helpdesk/attachments/production/2015052769380/original/2qGndtTgnnqS-fZWIdsTzdctL3SODwhzbg.png?1619440911" alt="Pix">
+                {% if  portal.current_page != 'csat_survey' %}
                     <a href="https://support.pix.org/" class="pix-app-header__title pix-app-header__title--black">
                         {% if portal.current_language.code == "fr" %}
                             Retour à l'accueil du centre d'aide
@@ -30,15 +32,16 @@
                             Back to Help centre's home
                         {% endif %}
                     </a>
-                </div>
-                {% if portal.current_tab != "search" %}
-                    <div class="pix-app-header__search-bar">
-                        {%  snippet search_form %}
-                    </div>
                 {% endif %}
             </div>
-        {% endif %}
-    </header>
+            {% if portal.current_tab != "search" and  portal.current_page != 'csat_survey'%}
+                <div class="pix-app-header__search-bar">
+                    {%  snippet search_form %}
+                </div>
+            {% endif %}
+        </div>
+    {% endif %}
+</header>
 
 {% if portal.current_tab == "solutions" or portal.current_tab == "search" %}
     <div class="pix-hero-banner">
@@ -90,15 +93,5 @@
       </ul>
     </div>
   </div>
-    </div>
-{% endif %}
-{% else %}
-  <header class="banner">
-    <div class="banner-wrapper">
-      <div class="banner-title">
-        {{ portal | logo : true }}
-        <h1 class="ellipsis heading">{{portal.name|h}}</h1>
-      </div>
-    </div>
-  </header>
+</div>
 {% endif %}


### PR DESCRIPTION
## :unicorn: Problème
Le header des enquetes de satisfaction était un cas unique de header dans le code. Il était différent et moche

## :robot: Solution
Le remettre dans les header normaux

## :rainbow: Remarques
Suppression d'un position absolute qui semblait gêner sur cette page et qui n'a pas d'impact sur les autres.