### PR TITLE
[BUGFIX] Réduit la distance d'animation au hover des cards

### DIFF
--- a/src/styles/components/_solution-card.scss
+++ b/src/styles/components/_solution-card.scss
@@ -68,7 +68,7 @@
   color: $nero;
   box-shadow: 0 14px 24px 0 rgba(12, 22, 58, 0.2),
     0 3px 6px 0 rgba(0, 0, 0, 0.2);
-  transform: translate3D(0, -20px, 0);
+  transform: translate3D(0, -8px, 0);
 
   @include device-is('desktop') {
   }


### PR DESCRIPTION
## :unicorn: Problème
L'animation au hover sur les cards est trop importante par rapport à nos pratiques actuelles.

## :robot: Solution
Réduction à 8px (multiple de 4).

## :rainbow: Remarques
Nous permet aussi de retester une release du site du support.
