### PR TITLE
[FEATURE] Ajouter des articles recommandés après la sélection du profil (PIX-4871)

### DIFF
--- a/src/styles/_ticket-page.scss
+++ b/src/styles/_ticket-page.scss
@@ -43,6 +43,11 @@
   .checkbox input[type="checkbox"]:focus:before,
   a:focus, a:hover, *:focus {
     border: 2px solid $dodger-blue;
+
+  }
+
+  a {
+    color:$dodger-blue;
   }
 
   input[type="submit"].btn-primary {
@@ -56,6 +61,7 @@
 
   a.btn {
     border: 2px solid transparent;
+    color: $nero;
 
     &:hover, &:focus {
       border: 2px solid white;

--- a/src/templates/NewTicket.twig
+++ b/src/templates/NewTicket.twig
@@ -150,18 +150,5 @@
                 setTimeout(resolve, 0);
             });
         }
-
-        /* Prend en entrée du texte ou des liens Markdown */
-        function buildMarkdownLinkIfNeeded(markdownLink) {
-            const regex = /^\[(.+)\]\((.+)\)$/;
-            if (!regex.match(markdownLink)) {
-                /* Retourne le texte d'entrée si pas de lien détecté */
-                return markdownLink;
-            }
-            const [_, text, url] = regex.exec(markdownLink);
-
-            /* Transforme le texte en hyperlien qui s'ouvre dans un nouvel onglet si lien reconnu */
-            return `<a href="${url}" target="_blank" rel="noopener noreferrer">${text}</a>`;
-        }
     </script>
 </main>

--- a/src/templates/NewTicket.twig
+++ b/src/templates/NewTicket.twig
@@ -15,36 +15,132 @@
     {% snippet new_ticket_form %}
 
     <script>
+        /* La liste des articles recommandés selon le type de profil.
+         * On se base sur le libellé du type de profil pour faire apparaitre les articles recommandés.
+         * /!\ Attention à ne pas avoir de différence entre les deux. */
+        const articlesRecommandes = {
+            "Je travaille dans l'enseignement scolaire": [
+                'Avez-vous consulté ces articles d’aide ?',
+                {
+                    lien: 'https://support.pix.org/fr/support/solutions/articles/15000047885',
+                    contenu: 'Un élève n’arrive pas à accéder à son parcours',
+                },
+                {
+                    lien: 'https://support.pix.org/fr/support/solutions/articles/15000029308',
+                    contenu: 'Organiser la certification dans mon établissement',
+                },
+                {
+                    lien: 'https://support.pix.org/fr/support/solutions/articles/15000047880',
+                    contenu: 'Un élève n’arrive pas à rentrer en session de certification',
+                },
+                {
+                    lien: 'https://support.pix.org/fr/support/solutions/articles/15000041114',
+                    contenu: 'Les résultats de certification ne sont pas encore disponibles',
+                },
+            ],
+        };
+
         /* /!\ Lié à la manière de Freshdesk de générer le formulaire
-        * Si celle ci évolue, les checkboxs resteront affichées et les liens resteront en textuel */
+         * Si celle ci évolue, les articles recommandés ne s'afficheront plus
+         * La section peut aussi se retrouver à un autre endroit */
         const ticketTypeInput = document.getElementById('helpdesk_ticket_ticket_type');
-        ticketTypeInput.addEventListener('change', displayRecommendedArticles);
+        const RECOMMENDED_ARTICLES_CLASS = 'pix-recommanded-articles';
+
+        try {
+            ticketTypeInput.addEventListener('change', displayRecommendedArticles);
+        } catch (error) {
+            displayFreshdeskError(error);
+        }
 
         function displayRecommendedArticles() {
-            waitForFreshdesk().then(() => {
-                /* /!\ Lié à la manière de Freshdesk de générer le formulaire
-                * Si celle ci évolue, les checkboxs resteront affichées et les liens resteront en textuel */
-                const articleLinkInputs = document.querySelectorAll('[id*="lienarticle"]');
-                for (let articleLinkInput of articleLinkInputs) {
-                    const articleLinkInputParent = articleLinkInput.parentNode.parentNode;
-                    const articleMarkdownLink = articleLinkInputParent.textContent.trim();
+            removeRecommandedArticleContainer();
 
-                    articleLinkInputParent.innerHTML = buildMarkdownLinkIfNeeded(articleMarkdownLink);
+            waitForFreshdesk().then(() => {
+                const ticketType = ticketTypeInput.value;
+                const articles = articlesRecommandes[ticketType];
+                if (articles) {
+                    const newRecommandedArticlesContainer = createRecommandedArticlesContainer(
+                        getRootNode(ticketTypeInput),
+                        getNextSibling(ticketTypeInput)
+                    );
+                    newRecommandedArticlesContainer.innerHTML =
+                        generateRecommandedArticlesHTMLContent(articles);
                 }
             });
         }
 
-        /* Prend en entrée du texte ou des liens Markdown */
-        function buildMarkdownLinkIfNeeded(markdownLink) {
-            const regex = /^\[(.+)\]\((.+)\)$/
-            if (!regex.match(markdownLink)) {
-                /* Retourne le texte d'entrée si pas de lien détecté */
-                return markdownLink;
+        function getRootNode(input) {
+            try {
+                const rootNode = input.parentNode.parentNode.parentNode;
+                if (!rootNode) {
+                    throw new Error();
+                }
+                return rootNode;
+            } catch (error) {
+                displayFreshdeskError(
+                    'Impossible de trouver le noeud suivant, il faut mettre à jour notre sélecteur'
+                );
             }
-            const [_, text, url] = regex.exec(markdownLink);
+        }
 
-            /* Transforme le texte en hyperlien qui s'ouvre dans un nouvel onglet si lien reconnu */
-            return `<a href="${url}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+        function getNextSibling(input) {
+            try {
+                const nextSibling = ticketTypeInput.parentNode.parentNode.nextSibling;
+                if (!nextSibling) {
+                    throw new Error();
+                }
+                return nextSibling;
+            } catch (error) {
+                displayFreshdeskError(
+                    'Impossible de trouver le noeud suivant, il faut mettre à jour notre sélecteur'
+                );
+            }
+        }
+
+        function displayFreshdeskError(error) {
+            console.log("Freshdesk a changé, les articles recommandés ne peuvent plus s'afficher");
+            console.log(error);
+        }
+
+        function createRecommandedArticlesContainer(rootNode, referenceNode) {
+            const recommandedArticlesContainer = document.createElement('section');
+            recommandedArticlesContainer.classList.add(RECOMMENDED_ARTICLES_CLASS,'controls','control-group');
+
+            rootNode.insertBefore(recommandedArticlesContainer, referenceNode);
+            return recommandedArticlesContainer;
+        }
+
+        function removeRecommandedArticleContainer() {
+            const alreadyRecommandedArticlesSection = document.getElementsByClassName(
+                RECOMMENDED_ARTICLES_CLASS
+            )[0];
+            if (alreadyRecommandedArticlesSection !== undefined) {
+                alreadyRecommandedArticlesSection.parentNode.removeChild(
+                    alreadyRecommandedArticlesSection
+                );
+            }
+        }
+
+        function generateRecommandedArticlesHTMLContent(articles) {
+            return articles
+                .map((article) => {
+                    if (typeof article === 'string') {
+                        return '<p>' + article + '</p>';
+                    } else if (
+                        typeof article === 'object' &&
+                        typeof article.lien === 'string' &&
+                        typeof article.contenu === 'string'
+                    ) {
+                        return (
+                            '<p><a href="' +
+                            article.lien.trim() +
+                            '" target="_blank" rel="noopener noreferrer">' +
+                            article.contenu.trim() +
+                            '</a></p>'
+                        );
+                    }
+                })
+                .join('');
         }
 
         /* Freshdesk ajoute son propre listener sur les champs imbriqués,
@@ -53,6 +149,19 @@
             return new Promise(function (resolve, reject) {
                 setTimeout(resolve, 0);
             });
+        }
+
+        /* Prend en entrée du texte ou des liens Markdown */
+        function buildMarkdownLinkIfNeeded(markdownLink) {
+            const regex = /^\[(.+)\]\((.+)\)$/;
+            if (!regex.match(markdownLink)) {
+                /* Retourne le texte d'entrée si pas de lien détecté */
+                return markdownLink;
+            }
+            const [_, text, url] = regex.exec(markdownLink);
+
+            /* Transforme le texte en hyperlien qui s'ouvre dans un nouvel onglet si lien reconnu */
+            return `<a href="${url}" target="_blank" rel="noopener noreferrer">${text}</a>`;
         }
     </script>
 </main>

--- a/src/templates/NewTicket.twig
+++ b/src/templates/NewTicket.twig
@@ -13,4 +13,46 @@
     {% endif %}
 
     {% snippet new_ticket_form %}
+
+    <script>
+        /* /!\ Lié à la manière de Freshdesk de générer le formulaire
+        * Si celle ci évolue, les checkboxs resteront affichées et les liens resteront en textuel */
+        const ticketTypeInput = document.getElementById('helpdesk_ticket_ticket_type');
+        ticketTypeInput.addEventListener('change', displayRecommendedArticles);
+
+        function displayRecommendedArticles() {
+            waitForFreshdesk().then(() => {
+                /* /!\ Lié à la manière de Freshdesk de générer le formulaire
+                * Si celle ci évolue, les checkboxs resteront affichées et les liens resteront en textuel */
+                const articleLinkInputs = document.querySelectorAll('[id*="lienarticle"]');
+                for (let articleLinkInput of articleLinkInputs) {
+                    const articleLinkInputParent = articleLinkInput.parentNode.parentNode;
+                    const articleMarkdownLink = articleLinkInputParent.textContent.trim();
+
+                    articleLinkInputParent.innerHTML = buildMarkdownLinkIfNeeded(articleMarkdownLink);
+                }
+            });
+        }
+
+        /* Prend en entrée du texte ou des liens Markdown */
+        function buildMarkdownLinkIfNeeded(markdownLink) {
+            const regex = /^\[(.+)\]\((.+)\)$/
+            if (!regex.match(markdownLink)) {
+                /* Retourne le texte d'entrée si pas de lien détecté */
+                return markdownLink;
+            }
+            const [_, text, url] = regex.exec(markdownLink);
+
+            /* Transforme le texte en hyperlien qui s'ouvre dans un nouvel onglet si lien reconnu */
+            return `<a href="${url}" target="_blank" rel="noopener noreferrer">${text}</a>`;
+        }
+
+        /* Freshdesk ajoute son propre listener sur les champs imbriqués,
+         * on attend qu'ils aient ajouté les champs conditionnel pour appliquer nos transformations */
+        function waitForFreshdesk() {
+            return new Promise(function (resolve, reject) {
+                setTimeout(resolve, 0);
+            });
+        }
+    </script>
 </main>


### PR DESCRIPTION
## :unicorn: Problème
Beaucoup de tickets utilisateurs sont créés alors que les réponses existent dans la FAQ.

## :robot: Solution
Dans cette PR, on améliore l'UX de la page de création de tickets.

On propose de permettre à l'équipe "Support" de lister des articles recommandés après que l'utilisateur ait sélectionné son profil (SCO, SUP, élève...).

~La solution consiste en l'ajout de champs des tickets checkbox avec un ID reconnaissable qu'on puisse scripter :~
~- la suppression de la checkbox (on n'attend pas que l'utilisateur coche quoi que ce soit mais c'est le seul champ où on peut ajouter du texte custom)~
~- la transformation des liens textuels en hyperliens cliquables~

La solution consiste en le stockage des articles recommandés dans un objet JSON qu'on retranscrit en liens (ou texte) après la sélection de son profil. On évite ainsi de stocker des infos inutiles sur les tickets.

## :rainbow: Remarques
Je ne suis pas 100% convaincu de la solution qui est très liée à Freshdesk, j'ai mis des commentaires aux endroits potentiellement impactés par des évols Freshdesk et ce que ça impacterai.

~On a choisi l'ID reconnaissable `lienarticle`, le nom est discutable.~

On pourrait ajouter un check sur la structure du DOM pour éviter d'ajouter la section au mauvais endroit si Freshdesk était amené à changer (mais on la perdrait probablement complètement dans ces cas là).