### PR TITLE
[BUGFIX] Ne pas afficher des articles recommandés FR sur la page de création de tickets EN

### DIFF
--- a/src/templates/NewTicket.liquid
+++ b/src/templates/NewTicket.liquid
@@ -47,11 +47,11 @@
             displayFreshdeskError(error);
         }
 
-        function displayRecommendedArticles() {
+        function displayRecommendedArticles(event) {
             removeRecommandedArticleContainer();
 
             waitForFreshdesk().then(() => {
-                const ticketType = ticketTypeInput.value;
+                const ticketType = event.target.selectedOptions[0].text;
                 const articles = articlesRecommandes[ticketType];
                 if (articles) {
                     const newRecommandedArticlesContainer = createRecommandedArticlesContainer(


### PR DESCRIPTION
## :unicorn: Problème
Le `value` sur l'élement `select#helpdesk_ticket_ticket_type` renvoie le nom français sur la page de création de tickets anglaise. Les tickets recommandés français apparaissent donc sur la page anglaise.

## :robot: Solution
Se baser sur la valeur textuelle affichée `event.target.selectedOptions[0].text` plutôt que sur la `value`

## :rainbow: Remarques
RAS
